### PR TITLE
chore: gitignore generated i18n message types [skip ci]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,12 +28,20 @@ node_modules/
 
 # misc
 .DS_Store
+*.pem
 .idea/
 
 # next.js
 .next/
 next-env.d.ts
 out/
+
+# self-signed certificates
+certificates
+
+# i18n
+/content/**/*.d.json.ts
+/messages/**/*.d.json.ts
 
 # test
 /coverage/
@@ -44,13 +52,18 @@ out/
 /playwright-report/
 /test-results/
 
+# typesense
+scripts/typesense/documents/
+
 
 ## .dockerignore ##
 
 # git
 .git/
 .gitattributes
-.gitignore
+# must be allowed because `tailwindcss` v4 will use `.gitignore` to determine which
+# files and folders can be skipped by the compiler.
+# .gitignore
 
 # github
 .github/
@@ -69,6 +82,3 @@ playwright.config.ts
 
 # misc
 .editorconfig
-
-# typesense
-scripts/typesense/documents/

--- a/.gitignore
+++ b/.gitignore
@@ -26,12 +26,20 @@ node_modules/
 
 # misc
 .DS_Store
+*.pem
 .idea/
 
 # next.js
 .next/
 next-env.d.ts
 out/
+
+# self-signed certificates
+certificates
+
+# i18n
+/content/**/*.d.json.ts
+/messages/**/*.d.json.ts
 
 # test
 /coverage/


### PR DESCRIPTION
this adds generated i18n message types to `.gitignore`, and also ensures `.gitignore` is not excluded from docker build context because it is needed by tailwind v4's compiler.