### PR TITLE
ci: share env vars, bump runner image to 24.04

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,14 +43,23 @@ jobs:
       fail-fast: true
       matrix:
         node-version: [22.x]
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
+
+    env:
+      NEXT_PUBLIC_APP_BASE_URL: "http://localhost:3000"
+      NEXT_PUBLIC_MATOMO_BASE_URL: "${{ vars.NEXT_PUBLIC_MATOMO_BASE_URL }}"
+      NEXT_PUBLIC_MATOMO_ID: "${{ vars.NEXT_PUBLIC_MATOMO_ID }}"
+      NEXT_PUBLIC_REDMINE_ID: "${{ vars.SERVICE_ID }}"
+      NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME: "${{ vars.NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME }}"
+      NEXT_PUBLIC_TYPESENSE_HOST: "${{ vars.NEXT_PUBLIC_TYPESENSE_HOST }}"
+      NEXT_PUBLIC_TYPESENSE_PORT: "${{ vars.NEXT_PUBLIC_TYPESENSE_PORT }}"
+      NEXT_PUBLIC_TYPESENSE_PROTOCOL: "${{ vars.NEXT_PUBLIC_TYPESENSE_PROTOCOL }}"
+      NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY: "${{ vars.NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY }}"
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Necessary because `actions/setup-node` does not yet support `corepack`.
-      # @see https://github.com/actions/setup-node/issues/531
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
@@ -100,42 +109,17 @@ jobs:
         with:
           path: "${{ github.workspace }}/.next/cache"
           key: "${{ matrix.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}"
+
       - name: Populate typesense
         run: pnpm run typesense:populate
         env:
-          NEXT_PUBLIC_APP_BASE_URL: "http://localhost:3000"
-          NEXT_PUBLIC_REDMINE_ID: "${{ vars.SERVICE_ID }}"
-          NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME: "${{ vars.NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME }}"
-          NEXT_PUBLIC_TYPESENSE_HOST: "${{ vars.NEXT_PUBLIC_TYPESENSE_HOST }}"
-          NEXT_PUBLIC_TYPESENSE_PORT: "${{ vars.NEXT_PUBLIC_TYPESENSE_PORT }}"
-          NEXT_PUBLIC_TYPESENSE_PROTOCOL: "${{ vars.NEXT_PUBLIC_TYPESENSE_PROTOCOL }}"
-          NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY: "${{ vars.NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY }}"
           TYPESENSE_ADMIN_API_KEY: "${{ secrets.TYPESENSE_ADMIN_API_KEY }}"
+
       - name: Build app
         run: pnpm run build
-        env:
-          NEXT_PUBLIC_APP_BASE_URL: "http://localhost:3000"
-          NEXT_PUBLIC_MATOMO_BASE_URL: "${{ vars.NEXT_PUBLIC_MATOMO_BASE_URL }}"
-          NEXT_PUBLIC_MATOMO_ID: "${{ vars.NEXT_PUBLIC_MATOMO_ID }}"
-          NEXT_PUBLIC_REDMINE_ID: "${{ vars.SERVICE_ID }}"
-          NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME: "${{ vars.NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME }}"
-          NEXT_PUBLIC_TYPESENSE_HOST: "${{ vars.NEXT_PUBLIC_TYPESENSE_HOST }}"
-          NEXT_PUBLIC_TYPESENSE_PORT: "${{ vars.NEXT_PUBLIC_TYPESENSE_PORT }}"
-          NEXT_PUBLIC_TYPESENSE_PROTOCOL: "${{ vars.NEXT_PUBLIC_TYPESENSE_PROTOCOL }}"
-          NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY: "${{ vars.NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY }}"
 
       - name: Run e2e tests
         run: pnpm run test:e2e
-        env:
-          NEXT_PUBLIC_APP_BASE_URL: "http://localhost:3000"
-          NEXT_PUBLIC_MATOMO_BASE_URL: "${{ vars.NEXT_PUBLIC_MATOMO_BASE_URL }}"
-          NEXT_PUBLIC_MATOMO_ID: "${{ vars.NEXT_PUBLIC_MATOMO_ID }}"
-          NEXT_PUBLIC_REDMINE_ID: "${{ vars.SERVICE_ID }}"
-          NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME: "${{ vars.NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME }}"
-          NEXT_PUBLIC_TYPESENSE_HOST: "${{ vars.NEXT_PUBLIC_TYPESENSE_HOST }}"
-          NEXT_PUBLIC_TYPESENSE_PORT: "${{ vars.NEXT_PUBLIC_TYPESENSE_PORT }}"
-          NEXT_PUBLIC_TYPESENSE_PROTOCOL: "${{ vars.NEXT_PUBLIC_TYPESENSE_PROTOCOL }}"
-          NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY: "${{ vars.NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY }}"
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}


### PR DESCRIPTION
this updates the github runner image to ubuntu 24.04, and moves shared env vars to the job level.