### PR TITLE
fix: include missing border-radius tokens in tailwind v4 theme

### DIFF
--- a/app/(app)/_components/app-footer.tsx
+++ b/app/(app)/_components/app-footer.tsx
@@ -31,10 +31,7 @@ export function AppFooter(): ReactNode {
 
 			<div className="grid gap-y-8">
 				<nav aria-label={t("navigation-secondary")}>
-					<ul
-						className="flex items-center gap-x-6 text-small text-neutral-600 xs:justify-center"
-						role="list"
-					>
+					<ul className="flex items-center gap-x-6 text-small xs:justify-center" role="list">
 						<li>
 							&copy; {new Date().getUTCFullYear()}{" "}
 							<a

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,9 +1,10 @@
-/* stylelint-disable custom-property-pattern */
 /* stylelint-disable color-no-hex */
 /* stylelint-disable custom-property-empty-line-before */
+/* stylelint-disable custom-property-pattern */
+/* stylelint-disable import-notation */
 
-@import url("tailwindcss");
-@import url("tw-animate-css");
+@import "tailwindcss";
+@import "tw-animate-css";
 
 @plugin "@tailwindcss/typography";
 @plugin "tailwindcss-react-aria-components";
@@ -15,6 +16,17 @@
 }
 
 @theme {
+	--radius-0: 0;
+	--radius-0_5: 0.125rem;
+	--radius-1: 0.25rem;
+	--radius-2: 0.5rem;
+	--radius-3: 0.75rem;
+	--radius-4: 1rem;
+	--radius-5: 1.25rem;
+	--radius-6: 1.5rem;
+	--radius-8: 2rem;
+	--radius-full: calc(infinity * 1px);
+
 	--color-primary-100: #e6f0f6;
 	--color-primary-200: #cde2ee;
 	--color-primary-300: #83b7d5;


### PR DESCRIPTION
this adds the border-radius design tokens which were accidentally omitted when migrating to tailwind v4. these are currently used by design system components, but we should consider moving to default tw rounded-* classes.